### PR TITLE
Export more symbols needed for smesh

### DIFF
--- a/libsrc/meshing/meshclass.hpp
+++ b/libsrc/meshing/meshclass.hpp
@@ -340,7 +340,7 @@ namespace netgen
     void SetDimension (int dim) { dimension = dim; }
 
     /// sets internal tables
-    void CalcSurfacesOfNode ();
+    DLL_HEADER void CalcSurfacesOfNode ();
 
     /// additional (temporarily) fix points 
     void FixPoints (const BitArray & fixpoints);

--- a/libsrc/meshing/meshtype.hpp
+++ b/libsrc/meshing/meshtype.hpp
@@ -352,15 +352,15 @@ namespace netgen
 
   public:
     ///
-    Element2d ();
+    DLL_HEADER Element2d ();
     ///
-    Element2d (int anp);
+    DLL_HEADER Element2d (int anp);
     ///
     DLL_HEADER Element2d (ELEMENT_TYPE type);
     ///
-    Element2d (int pi1, int pi2, int pi3);
+    DLL_HEADER Element2d (int pi1, int pi2, int pi3);
     ///
-    Element2d (int pi1, int pi2, int pi3, int pi4);
+    DLL_HEADER Element2d (int pi1, int pi2, int pi3, int pi4);
     ///
     ELEMENT_TYPE GetType () const { return typ; }
     /// 

--- a/libsrc/occ/occgeom.hpp
+++ b/libsrc/occ/occgeom.hpp
@@ -244,7 +244,7 @@ namespace netgen
       }
 
 
-     virtual void Save (string filename) const;
+      DLL_HEADER virtual void Save (string filename) const;
 
 
       DLL_HEADER void BuildFMap();
@@ -275,7 +275,7 @@ namespace netgen
          return OCCSurface (TopoDS::Face(fmap(surfi)), PLANESPACE);
       }
 
-      void CalcBoundingBox ();
+      DLL_HEADER void CalcBoundingBox ();
       DLL_HEADER void BuildVisualizationMesh (double deflection);
 
       void RecursiveTopologyTree (const TopoDS_Shape & sh,
@@ -440,7 +440,7 @@ namespace netgen
    // Philippose - 31.09.2009
    // External access to the mesh generation functions within the OCC
    // subsystem (Not sure if this is the best way to implement this....!!)
-   extern int OCCGenerateMesh (OCCGeometry & occgeometry, shared_ptr<Mesh> & mesh,
+   DLL_HEADER extern int OCCGenerateMesh (OCCGeometry & occgeometry, shared_ptr<Mesh> & mesh,
 			       MeshingParameters & mparam);
 
    DLL_HEADER extern void OCCSetLocalMeshSize(OCCGeometry & geom, Mesh & mesh);

--- a/libsrc/occ/occmeshsurf.hpp
+++ b/libsrc/occ/occmeshsurf.hpp
@@ -4,6 +4,7 @@
 #define FILE_OCCMESHSURF
 
 #include "occgeom.hpp"
+#include "mydefs.hpp"
 
 #define PARAMETERSPACE -1
 #define PLANESPACE     1
@@ -169,7 +170,7 @@ public:
 class OCCGeometry;
 
 
-class OCCRefinementSurfaces : public Refinement
+class DLL_HEADER OCCRefinementSurfaces : public Refinement
 {
   const OCCGeometry & geometry;
 


### PR DESCRIPTION
If the entire classes were exported instead of individual functions,
we wouldn't be having this problem....